### PR TITLE
Remove version column from CLAUDE.md plugin table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,12 +30,14 @@ the `github` source type in production (e.g., `browserbase/agent-browse`).
 
 ## Registered Plugins
 
-| Plugin | Source Repo | Version |
-|---|---|---|
-| `cli-ux-tester` | `ali5ter/claude-cli-ux-skill` | 3.0.0 |
-| `obsidian-project-documentation` | `ali5ter/obsidian-project-assistant` | 3.2.0 |
-| `over-50s-health` | `ali5ter/over-50s-health-advisor` | 3.2.0 |
-| `pair-programmer` | `ali5ter/pair-programmer` | 1.0.0 |
+Versions are maintained in `.claude-plugin/marketplace.json` (source of truth) and `README.md`.
+
+| Plugin | Source Repo |
+|---|---|
+| `cli-ux-tester` | `ali5ter/claude-cli-ux-skill` |
+| `obsidian-project-documentation` | `ali5ter/obsidian-project-assistant` |
+| `over-50s-health` | `ali5ter/over-50s-health-advisor` |
+| `pair-programmer` | `ali5ter/pair-programmer` |
 
 ## Install Commands
 
@@ -52,7 +54,7 @@ the `github` source type in production (e.g., `browserbase/agent-browse`).
 1. Ensure the plugin's repo has `.claude-plugin/plugin.json` at its root.
 2. Remove `.claude-plugin/marketplace.json` from the plugin repo if present (no longer needed).
 3. Add an entry to `.claude-plugin/marketplace.json` in this repo following the existing schema.
-4. Update the plugin table in `README.md` and this file.
+4. Update the plugin table in `README.md`.
 5. Commit and push.
 6. Run `/plugin marketplace update ali5ter` in Claude Code before installing — the plugin
    installer uses a cached copy of the catalog and will not see new or renamed plugins without


### PR DESCRIPTION
## Summary

- Removes the `Version` column from the plugin table in `CLAUDE.md`
- Adds a note pointing to `marketplace.json` as the source of truth for versions
- Updates the "Adding a New Plugin" step to no longer mention updating `CLAUDE.md`

## Why

Versions existed in three places (`marketplace.json`, `README.md`, `CLAUDE.md`), creating unnecessary sync burden. They've already drifted once (fixed in ff4867b). `CLAUDE.md` is not user-facing, so it doesn't need version numbers — `marketplace.json` is authoritative and `README.md` is the user-visible surface.

Closes #2.

## Test plan

- [ ] `CLAUDE.md` plugin table no longer has a `Version` column
- [ ] Note in `CLAUDE.md` points to `marketplace.json` and `README.md` as the version sources
- [ ] "Adding a New Plugin" steps no longer mention updating `CLAUDE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)